### PR TITLE
Fix several spelling mistakes

### DIFF
--- a/agent/man/mailagent.SH
+++ b/agent/man/mailagent.SH
@@ -457,7 +457,7 @@ not. The value of this variable is used in place of \fIsecure\fR when checking
 executable files. (defaults to OFF, suggested: ON if possible).
 .TP
 .I execskip
-Whether to skip the \fIexec()\fR security checks alltogether. Don't turn
+Whether to skip the \fIexec()\fR security checks altogether. Don't turn
 this ON unless you really trust all the users having access to your machine
 or file server. (optional, default to OFF, suggested: OFF).
 .TP
@@ -543,7 +543,7 @@ dumped to an emergency mailbox. (optional, defaults to ON).
 .TP
 .I lockwarn
 This variable controls the time after which \fImailagent\fR should
-start emiting a warning when busy trying to acquire a lock.
+start emitting a warning when busy trying to acquire a lock.
 It is a comma separated list of values, in seconds. If two values are
 given, the first is the initial time threshold, the second is the
 repeat period. For instance, a value of "15,60" would cause a warning
@@ -1350,7 +1350,7 @@ the pattern \fI/Raphael/\fR would match, but not \fI/^Raphael/\fR. Instead,
 \fI/^ram@.*$/\fR would match, but this is more easily done with a single word
 pattern \fIram\fR, for it only focuses on the login name of the address and
 would also match if the address was written as \fIeiffel.com!ram\fR.  A single
-address in Internet form, as in \fIram@eiffel.com\fR is implicitely matching
+address in Internet form, as in \fIram@eiffel.com\fR is implicitly matching
 on the address part of the field, and you must not escape the '.' as you
 would have to in a regular expression.
 .PP
@@ -1960,7 +1960,7 @@ You still have to parse the MIME parts yourself though.
 .sp
 Using
 .B -b
-does not prevent your program from outputing a valid message back, one
+does not prevent your program from outputting a valid message back, one
 that can be possibly sent on the network so you have two options:
 either you do not supply any Content-Transfer-Encoding in the headers,
 and mailagent will recode the body for you using the initial transfer
@@ -4892,7 +4892,7 @@ to quietly redefine a commonly used standard command like LEAVE and later
 be able to assume your identity.
 .PP
 Versions after 3.0 PL44 come with an improved (from a security point of view) C
-\fIfilter\fR that will not only perform the aforementionned checks but will
+\fIfilter\fR that will not only perform the aforementioned checks but will
 also ensure that the \fIperl\fR executable and the \fImailagent\fR script
 it is about to exec are not loosely protected (when \fIexecsafe\fR is ON or
 when running with superuser privileges).
@@ -4906,7 +4906,7 @@ as well as mail hooks, are checked for obvious protection flaws before being
 actually run
 Interpreted scripts (starting with the #! magic token) and
 perl scripts following the magic "exec perl if \$under_shell" incantation are
-specially checked for further security of the relevant interpretor. Those
+specially checked for further security of the relevant interpreter. Those
 checks are performed systematically
 (when \fIexecsafe\fR is ON or when running with superuser privileges)
 even if the \fIsecure\fR parameter was

--- a/agent/pl/install.pl
+++ b/agent/pl/install.pl
@@ -410,7 +410,7 @@ sub create {
 #
 # If a file is spefied as:
 #        mailbox = f ($maildrop)
-# in the setup.cf file, then it means the optional file is implicitely located
+# in the setup.cf file, then it means the optional file is implicitly located
 # under another configuration variable or specified path. Use that if necessary.
 # Note that if a variable is specified, it is assumed to be a configuration
 # variable and is therefore evaluated in the cf package. It is possible to

--- a/agent/pl/secure.pl
+++ b/agent/pl/secure.pl
@@ -276,7 +276,7 @@ sub exec_secure {
 	return 1 unless -T $file;	# Safe as far as we can tell, unless script...
 
 	local($head);				# Heading line
-	local($interpretor);		# Interpretor running the script
+	local($interpretor);		# Interpreter running the script
 	local($perl) = '';			# Empiric support for perl scripts
 	local(*SCRIPT);
 
@@ -310,7 +310,7 @@ sub exec_secure {
 	}
 
 	unless (&file_secure($interpretor, 'interpretor', 1)) {
-		&add_log("ERROR cannot run unsecure interpretor $interpretor")
+		&add_log("ERROR cannot run unsecure interpreter $interpretor")
 			if $loglvl > 1;
 		&add_log("ERROR cannot allow execution of script $file") if $loglvl > 1;
 		return 0;

--- a/agent/pl/stats.pl
+++ b/agent/pl/stats.pl
@@ -567,7 +567,7 @@ sub print_general {
 	$n = $Special{'saved'};
 	$s = $n == 1 ? '' : 's';
 	local($was) = $n == 1 ? 'was' : 'were';
-	print " and $n message$s $was implicitely saved" if $n;
+	print " and $n message$s $was implicitly saved" if $n;
 	print ".\n";
 	$n = $Special{'vacation'};
 	$s = $n == 1 ? '' : 's';


### PR DESCRIPTION
There are some instance of "interpretor" in agent/pl/secure.pl which have not been changed to "interpreter", because they appear in the variable name $interpretor.